### PR TITLE
Hotfix/20260527.1

### DIFF
--- a/src/handlers/error.handler.ts
+++ b/src/handlers/error.handler.ts
@@ -209,8 +209,9 @@ export class ErrorHandler extends StateManager {
         filename: event.filename,
         line: event.lineno,
         // Inline-script errors report the page URL as `filename`; passing the current
-        // page URL lets buildErrorSignatureKey collapse them to origin, byte-identical
-        // to the server cap/dedup hash. normalizeFilename strips query/hash internally.
+        // page URL lets buildErrorSignatureKey collapse them to origin, matching the
+        // normalized input the server hashes for cap/dedup. normalizeFilename strips
+        // query/hash internally.
         page_url: window.location.href,
       })
     ) {

--- a/src/handlers/error.handler.ts
+++ b/src/handlers/error.handler.ts
@@ -165,12 +165,13 @@ export class ErrorHandler extends StateManager {
    * silences identical repeats, and double-counting here would skew the cap for any
    * later signature that recycles the same map key after a counter reset.
    */
-  private shouldThrottleBySignature(input: { message: string; filename?: string; line?: number }): boolean {
-    const key = buildErrorSignatureKey({
-      message: input.message,
-      filename: input.filename,
-      line: input.line,
-    });
+  private shouldThrottleBySignature(input: {
+    message: string;
+    filename?: string;
+    line?: number;
+    page_url?: string;
+  }): boolean {
+    const key = buildErrorSignatureKey(input);
     const current = this.pageviewSignatureCounts.get(key) ?? 0;
 
     if (current >= MAX_ERRORS_PER_SIGNATURE_PER_PAGEVIEW) {
@@ -207,6 +208,10 @@ export class ErrorHandler extends StateManager {
         message: sanitizedMessage,
         filename: event.filename,
         line: event.lineno,
+        // Inline-script errors report the page URL as `filename`; passing the current
+        // page URL lets buildErrorSignatureKey collapse them to origin, byte-identical
+        // to the server cap/dedup hash. normalizeFilename strips query/hash internally.
+        page_url: window.location.href,
       })
     ) {
       return;

--- a/src/utils/error-signature.utils.ts
+++ b/src/utils/error-signature.utils.ts
@@ -3,14 +3,17 @@
  *
  * SOURCE: tracelog-api/src/lib/error-classification/error-fingerprint.service.ts
  *
- * The regex set below MUST stay byte-identical to the API's `normalizeErrorMessage`
- * so that client-side throttling and server-side dedup agree on what counts as the
- * "same" error. The lib's variant skips the SHA-256 step the API performs after
- * normalization: the throttle map key is the composite string itself, avoiding a
- * `crypto` import and shaving bytes from the browser bundle.
+ * The regex set AND `normalizeFilename` below MUST stay byte-identical to the API's
+ * `normalizeErrorMessage` / `normalizeFilename` so that client-side throttling and
+ * server-side cap/dedup agree on what counts as the "same" error. The lib's variant
+ * skips the SHA-256 step the API performs after normalization: the throttle map key is
+ * the composite string itself, avoiding a `crypto` import and shaving bytes from the
+ * browser bundle.
  *
- * If either side changes the regex set, update both AND adjust the unit test that
- * codifies the expected outputs against fixed inputs (`error-signature.utils.test.ts`).
+ * If either side changes the regex set, `normalizeFilename`, or the `ErrorSignatureInput`
+ * shape, update both AND adjust the unit tests that codify the expected outputs against
+ * fixed inputs (`error-signature.utils.test.ts` here, `error-fingerprint.service.spec.ts`
+ * in the API).
  */
 
 const URL_PATTERN = /https?:\/\/\S+/g;
@@ -23,6 +26,12 @@ export interface ErrorSignatureInput {
   message: string;
   filename?: string;
   line?: number | string;
+  /**
+   * Full page URL where the error fired. Inline-script errors report the page URL as
+   * `filename`; when they match, the signature collapses to the URL origin (see
+   * `normalizeFilename`). Optional — omit when no page context is available.
+   */
+  page_url?: string;
 }
 
 export function normalizeErrorMessage(message: string): string {
@@ -36,12 +45,41 @@ export function normalizeErrorMessage(message: string): string {
     .trim();
 }
 
+/** Cut a string at the first `?` or `#`. Shared by filename + page-URL normalization. */
+function stripQueryHash(value: string): string {
+  const cut = value.search(/[?#]/);
+  return cut === -1 ? value : value.slice(0, cut);
+}
+
+/**
+ * MIRROR of `ErrorFingerprintService.normalizeFilename` in the API — MUST produce
+ * byte-identical output.
+ *
+ * Browsers report the PAGE URL as `filename` for inline-script errors. When
+ * `filename === page_url` (query/hash stripped from both) collapse to the URL `origin`
+ * so one theme bug = one signature across pages. Real asset URLs on another path keep
+ * their full URL (the path discriminates distinct assets); `data:` / `blob:` and other
+ * non-http(s) schemes have no stable identity → `''`; relative / bare names (`bundle.js`)
+ * and malformed input fall back to the query/hash-stripped raw string.
+ */
+function normalizeFilename(filename: string | undefined, pageUrl?: string): string {
+  const raw = stripQueryHash((filename ?? '').trim());
+  if (!raw) return '';
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return raw;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return '';
+  const page = stripQueryHash((pageUrl ?? '').trim());
+  if (page && raw === page) return parsed.origin;
+  return raw;
+}
+
 export function buildErrorSignatureKey(input: ErrorSignatureInput): string {
   const message = normalizeErrorMessage(input.message);
-  const rawFilename = (input.filename ?? '').trim();
-  // Strip query string and hash fragment so UTM / campaign params don't split signatures.
-  const cut = rawFilename.search(/[?#]/);
-  const filename = cut === -1 ? rawFilename : rawFilename.slice(0, cut);
+  const filename = normalizeFilename(input.filename, input.page_url);
   const line = input.line == null ? '' : String(input.line);
   return `${message}|${filename}|${line}`;
 }

--- a/tests/unit/handlers/error-handler.test.ts
+++ b/tests/unit/handlers/error-handler.test.ts
@@ -797,4 +797,39 @@ describe('ErrorHandler - Per-Pageview Signature Throttle', () => {
       localHandler.stopTracking();
     }
   });
+
+  it('collapses inline-script errors across SPA paths to one origin signature', () => {
+    // The real-world case the `page_url` wiring exists for: an inline-script (theme) error
+    // reports the browser's page URL as `filename`. handleError passes window.location.href
+    // as page_url, so buildErrorSignatureKey collapses each path to the shared origin —
+    // four such errors across two paths within one pageview hit the SAME per-pageview cap
+    // instead of fragmenting into one signature per path. Distinct numeric content bypasses
+    // the 5s identical-message window while normalizing to the same `failed to load [n]`.
+    const originalPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+    try {
+      history.pushState({}, '', '/collections/kids');
+      window.dispatchEvent(
+        new ErrorEvent('error', { message: 'Failed to load 10001', filename: window.location.href, lineno: 7 }),
+      );
+      window.dispatchEvent(
+        new ErrorEvent('error', { message: 'Failed to load 10002', filename: window.location.href, lineno: 7 }),
+      );
+
+      history.pushState({}, '', '/collections/adults');
+      window.dispatchEvent(
+        new ErrorEvent('error', { message: 'Failed to load 10003', filename: window.location.href, lineno: 7 }),
+      );
+      window.dispatchEvent(
+        new ErrorEvent('error', { message: 'Failed to load 10004', filename: window.location.href, lineno: 7 }),
+      );
+
+      const errorCalls = trackSpy.mock.calls.filter(
+        (call) => (call[0] as { type?: EventType }).type === EventType.ERROR,
+      );
+      expect(errorCalls).toHaveLength(MAX_ERRORS_PER_SIGNATURE_PER_PAGEVIEW);
+    } finally {
+      history.pushState({}, '', originalPath || '/');
+    }
+  });
 });

--- a/tests/unit/utils/error-signature.utils.test.ts
+++ b/tests/unit/utils/error-signature.utils.test.ts
@@ -1,10 +1,13 @@
 /**
  * Error Signature Utils Tests
  *
- * Codifies the byte-for-byte parity between the lib's `normalizeErrorMessage` and the
- * API's `ErrorFingerprintService.normalizeErrorMessage`. If the API regex set changes
- * in `tracelog-api/src/lib/error-classification/error-fingerprint.service.ts`, this
- * file MUST be updated in lockstep or the lib build will surface the drift.
+ * Codifies the byte-for-byte parity between the lib's `normalizeErrorMessage` /
+ * `buildErrorSignatureKey` (which embeds `normalizeFilename`) and the API's
+ * `ErrorFingerprintService`. If the API regex set, `normalizeFilename`, or the
+ * `ErrorSignatureInput` shape changes in
+ * `tracelog-api/src/lib/error-classification/error-fingerprint.service.ts`, this file
+ * MUST be updated in lockstep or the lib build will surface the drift. The fixtures
+ * here mirror those in `error-fingerprint.service.spec.ts`.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -73,5 +76,57 @@ describe('buildErrorSignatureKey', () => {
     expect(buildErrorSignatureKey({ message: 'Boom', filename: 'a.js', line: 1 })).toBe(
       buildErrorSignatureKey({ message: 'Boom', filename: 'a.js', line: '1' }),
     );
+  });
+
+  it('collapses inline-script errors (filename === page_url) to the origin across pages', () => {
+    const a = buildErrorSignatureKey({
+      message: 'Boom',
+      filename: 'https://koopsbrand.com/collections/kids',
+      line: 42,
+      page_url: 'https://koopsbrand.com/collections/kids',
+    });
+    const b = buildErrorSignatureKey({
+      message: 'Boom',
+      filename: 'https://koopsbrand.com/collections/barefoot-for-adults',
+      line: 42,
+      page_url: 'https://koopsbrand.com/collections/barefoot-for-adults',
+    });
+    expect(a).toBe(b);
+    expect(a).toBe('boom|https://koopsbrand.com|42');
+  });
+
+  it('collapses inline-script errors even when query/hash differ between filename and page_url', () => {
+    expect(
+      buildErrorSignatureKey({
+        message: 'Boom',
+        filename: 'https://koopsbrand.com/products/foo?utm_source=facebook',
+        line: 42,
+        page_url: 'https://koopsbrand.com/products/foo?fbclid=abc',
+      }),
+    ).toBe('boom|https://koopsbrand.com|42');
+  });
+
+  it('does NOT collapse a real asset URL served from a path other than the page', () => {
+    expect(
+      buildErrorSignatureKey({
+        message: 'Boom',
+        filename: 'https://cdn.shopify.com/s/files/1/app.js',
+        line: 10,
+        page_url: 'https://koopsbrand.com/collections/kids',
+      }),
+    ).toBe('boom|https://cdn.shopify.com/s/files/1/app.js|10');
+  });
+
+  it('drops data: and blob: filenames (no stable identity)', () => {
+    expect(buildErrorSignatureKey({ message: 'Boom', filename: 'data:text/javascript,console.log(1)', line: 1 })).toBe(
+      'boom||1',
+    );
+    expect(
+      buildErrorSignatureKey({ message: 'Boom', filename: 'blob:https://koopsbrand.com/9f3c-uuid', line: 1 }),
+    ).toBe('boom||1');
+  });
+
+  it('returns an empty filename segment for whitespace-only filename', () => {
+    expect(buildErrorSignatureKey({ message: 'Boom', filename: '   ', line: 1 })).toBe('boom||1');
   });
 });

--- a/tests/unit/utils/error-signature.utils.test.ts
+++ b/tests/unit/utils/error-signature.utils.test.ts
@@ -117,13 +117,16 @@ describe('buildErrorSignatureKey', () => {
     ).toBe('boom|https://cdn.shopify.com/s/files/1/app.js|10');
   });
 
-  it('drops data: and blob: filenames (no stable identity)', () => {
+  it('drops data:/blob:/file: and other non-http(s) schemes (no stable identity)', () => {
     expect(buildErrorSignatureKey({ message: 'Boom', filename: 'data:text/javascript,console.log(1)', line: 1 })).toBe(
       'boom||1',
     );
     expect(
       buildErrorSignatureKey({ message: 'Boom', filename: 'blob:https://koopsbrand.com/9f3c-uuid', line: 1 }),
     ).toBe('boom||1');
+    expect(buildErrorSignatureKey({ message: 'Boom', filename: 'file:///Users/dev/theme/app.js', line: 1 })).toBe(
+      'boom||1',
+    );
   });
 
   it('returns an empty filename segment for whitespace-only filename', () => {


### PR DESCRIPTION
## What

Mirrors the API's inline-script filename **origin-collapse** into the lib's client-side error-signature builder (`buildErrorSignatureKey`), and wires the page URL through the `error` handler.

## Why

Browsers report the **page URL** as `filename` for inline-script (e.g. theme) errors. Without normalization, one logical bug shatters into a distinct signature per visited path (`/collections/kids`, `/collections/adults`, …). Collapsing `filename === page_url` to the URL **origin** keeps the client throttle key's normalized input byte-identical to what the server hashes for cap/dedup, so client and server agree on what counts as the "same" error.

## Changes

- `src/utils/error-signature.utils.ts` — add `normalizeFilename` + shared `stripQueryHash`, and the optional `page_url` field on `ErrorSignatureInput`. Logic is a byte-identical mirror of `ErrorFingerprintService.normalizeFilename` (the lib skips the API's SHA-256 step — the throttle key is the composite string itself).
- `src/handlers/error.handler.ts` — pass `page_url: window.location.href` from `handleError`. The `unhandledrejection` path intentionally omits it (rejections have no filename).
- Tests — 5 util fixtures mirroring `error-fingerprint.service.spec.ts`, plus a handler-level test proving inline errors across SPA paths collapse to one per-pageview cap.

## Cross-package

API half already landed in `tracelog-api` (`af53c8ba`). This is the lib mirror. The two `normalizeFilename` implementations and their pinned fixtures MUST stay in lockstep.

## Risk

Low. The per-pageview throttle map resets on every `PAGE_VIEW`, so within a single pageview behavior is unchanged (all inline errors already shared the page URL). The real payoff is cross-pageview/session parity with the server cap/dedup.

## Verification

- `npm run type-check` — 0 errors
- `npm run test:unit` — 767/767 pass (36 files)
- `npm run check` — 0 lint errors, Prettier clean

Internal change only — `ErrorSignatureInput` / `normalizeFilename` are not exported, so no public API surface or `API_REFERENCE.md` change.
