### PR TITLE
feat(pixel): add Shopify Custom Web Pixel snippet entry point

### DIFF
--- a/src/pixel/custom-pixel-snippet.ts
+++ b/src/pixel/custom-pixel-snippet.ts
@@ -1,0 +1,20 @@
+/**
+ * Entry point for the browser IIFE bundle embedded in TraceLog's dashboard as a paste-able Shopify
+ * Custom Web Pixel snippet (Settings → Customer events → Add custom pixel — no app install required).
+ *
+ * Exports ONLY the two low-level primitives the pasted snippet calls directly: `mapEventToBody`
+ * (shapes one Shopify pixel event into the ingest payload) and `sendBatch` (posts it). Deliberately
+ * excludes `registerShopifyPixel`, which subscribes to the full 7-event funnel — this snippet is
+ * revenue-only, so the merchant's pasted code carries a single, literal, top-level
+ * `analytics.subscribe('checkout_completed', ...)` call. Shopify's static pixel analyzer only
+ * recognizes a literal, unindirected `analytics.subscribe(event, handler)` call in the pixel's own
+ * script, not one buried inside a bundled helper function — so the subscribe call must live in the
+ * merchant's pasted code, not in this bundle.
+ *
+ * Built via `vite.pixel.config.mjs` into `dist/browser/tracelog-shopify-pixel.iife.js`
+ * (`npm run build:pixel`). Distinct from the `@tracelog/lib/pixel` subpath (`src/pixel/index.ts`),
+ * which stays the full API (including `registerShopifyPixel`) consumed by the OAuth Shopify app's
+ * own Web Pixel extension.
+ */
+export { mapEventToBody } from './event-mapper';
+export { sendBatch } from './pixel-sender';

--- a/tests/unit/pixel/custom-pixel-snippet.test.ts
+++ b/tests/unit/pixel/custom-pixel-snippet.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Shopify Custom Web Pixel snippet entry — export surface tests
+ *
+ * `custom-pixel-snippet.ts` is the Vite entry (`vite.pixel.config.mjs`) for the dashboard's
+ * paste-able revenue-only snippet. It MUST expose exactly `mapEventToBody` + `sendBatch` and
+ * MUST NOT expose `registerShopifyPixel` — that helper subscribes to the full 7-event funnel,
+ * which would let the merchant accidentally double-subscribe or bypass the literal top-level
+ * `analytics.subscribe('checkout_completed', ...)` call Shopify's static analyzer requires.
+ * The dashboard hand-copies the compiled bundle as a string (`SHOPIFY_PIXEL_BUNDLE_JS` in
+ * tracelog-app), so an accidental export change here would silently drift undetected otherwise.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as customPixelSnippet from '../../../src/pixel/custom-pixel-snippet';
+
+describe('custom-pixel-snippet entry exports', () => {
+  it('exposes exactly mapEventToBody and sendBatch', () => {
+    expect(Object.keys(customPixelSnippet).sort()).toEqual(['mapEventToBody', 'sendBatch']);
+  });
+
+  it('does not expose registerShopifyPixel', () => {
+    expect('registerShopifyPixel' in customPixelSnippet).toBe(false);
+  });
+
+  it('re-exports the same function references as the full pixel API', async () => {
+    const fullApi = await import('../../../src/pixel/index');
+    expect(customPixelSnippet.mapEventToBody).toBe(fullApi.mapEventToBody);
+    expect(customPixelSnippet.sendBatch).toBe(fullApi.sendBatch);
+  });
+});

--- a/vite.pixel.config.mjs
+++ b/vite.pixel.config.mjs
@@ -3,10 +3,12 @@ import { resolve } from 'path';
 import { fileURLToPath, URL } from 'node:url';
 
 /**
- * Vite Build Configuration for the Shopify Web Pixel Extension Bundle
+ * Vite Build Configuration for the Shopify Custom Web Pixel snippet bundle
  *
- * Produces a self-contained IIFE bundle for the Shopify Web Pixel Extension
- * (Task 07): no runtime deps, target ES2020, terser-minified.
+ * Produces a self-contained IIFE bundle for the dashboard's paste-able Shopify Custom Web Pixel
+ * snippet (revenue wizard, no-app path): no runtime deps, target ES2020, terser-minified. Exposes
+ * only `mapEventToBody` / `sendBatch` (see `src/pixel/custom-pixel-snippet.ts`) — the merchant's
+ * pasted code adds its own literal `analytics.subscribe('checkout_completed', ...)` call around them.
  *
  * Output:
  *   dist/browser/tracelog-shopify-pixel.iife.js
@@ -20,7 +22,7 @@ export default defineConfig({
   },
   build: {
     lib: {
-      entry: resolve(fileURLToPath(new URL('.', import.meta.url)), 'src/pixel/index.ts'),
+      entry: resolve(fileURLToPath(new URL('.', import.meta.url)), 'src/pixel/custom-pixel-snippet.ts'),
       name: 'TraceLogShopifyPixel',
       formats: ['iife'],
       fileName: () => 'tracelog-shopify-pixel.iife.js',


### PR DESCRIPTION
The dashboard's revenue wizard embeds a compiled bundle of this as a paste-able Shopify Custom Web Pixel snippet (no-app revenue path). The entry exposes only mapEventToBody/sendBatch — never registerShopifyPixel, which subscribes to the full 7-event funnel the OAuth Web Pixel extension uses; this pixel is revenue-only, so the merchant's pasted code adds its own literal analytics.subscribe('checkout_completed', ...) call.

Refs: TRA-115