### PR TITLE
docs(pixel): name the revenue path, not the work item that built it

### DIFF
--- a/src/pixel/pixel-sender.ts
+++ b/src/pixel/pixel-sender.ts
@@ -5,7 +5,7 @@
  * `api.tracelog.io/events/collect` — because the middleware has the only CORS
  * handler that accepts `Origin: null` from sandboxed iframes.
  *
- * Best-effort: failures are silently swallowed. The webhook (Task 03) carries
+ * Best-effort: failures are silently swallowed. The order webhook is what carries
  * the revenue contract; pixel events are funnel-only and accept ~5-30% loss.
  */
 


### PR DESCRIPTION
The sender's header cited "(Task 03)" for the component that carries the revenue
contract. A reader needs to know it is the order webhook — which stays true — not which
piece of work introduced it, which stops resolving to anything once the board moves on.

Comment only.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
