### PR TITLE
TRA-472 Propagate durable ingestion receipts

### DIFF
--- a/src/managers/sender.manager.ts
+++ b/src/managers/sender.manager.ts
@@ -27,14 +27,16 @@ import {
   PermanentError,
   RateLimitError,
   TimeoutError,
+  type IngestionReceipt,
+  parseIngestionReceipt,
 } from '../types';
 import { log } from '../utils';
 import { StorageManager } from './storage.manager';
 import { StateManager } from './state.manager';
 
 interface SendCallbacks {
-  onSuccess?: (eventCount?: number, events?: any[], body?: EventsQueue) => void;
-  onFailure?: () => void;
+  onSuccess?: (eventCount?: number, events?: any[], body?: EventsQueue, receipt?: IngestionReceipt) => void;
+  onFailure?: (receipt?: IngestionReceipt) => void;
 }
 
 /**
@@ -78,6 +80,7 @@ export class SenderManager extends StateManager {
   private readonly storeManager: StorageManager;
   private readonly apiUrl: string;
   private lastPermanentErrorLog: { key: string; timestamp: number } | null = null;
+  private lastIngestionReceipt: IngestionReceipt | null = null;
   /**
    * In-memory fallback for the beacon throttle when localStorage is
    * unavailable. The primary throttle state lives in localStorage (see
@@ -336,13 +339,19 @@ export class SenderManager extends StateManager {
    */
   async sendEventsQueue(body: EventsQueue, callbacks?: SendCallbacks): Promise<boolean> {
     const stableBody = this.ensureBatchMetadata(body);
+    this.lastIngestionReceipt = null;
 
     try {
       const success = await this.send(stableBody);
 
       if (success) {
         this.clearPersistedEvents();
-        callbacks?.onSuccess?.(stableBody.events.length, stableBody.events, stableBody);
+        callbacks?.onSuccess?.(
+          stableBody.events.length,
+          stableBody.events,
+          stableBody,
+          this.lastIngestionReceipt ?? undefined,
+        );
       } else {
         this.persistEvents(stableBody);
         callbacks?.onFailure?.();
@@ -351,9 +360,10 @@ export class SenderManager extends StateManager {
       return success;
     } catch (error) {
       if (error instanceof PermanentError) {
+        this.lastIngestionReceipt = error.ingestionReceipt ?? null;
         this.logPermanentError('Permanent error, not retrying', error);
         this.clearPersistedEvents();
-        callbacks?.onFailure?.();
+        callbacks?.onFailure?.(this.lastIngestionReceipt ?? undefined);
         return false;
       }
 
@@ -375,6 +385,7 @@ export class SenderManager extends StateManager {
     }
 
     this.recoveryInProgress = true;
+    this.lastIngestionReceipt = null;
 
     let recoveryBody: EventsQueue | null = null;
     let recoveryFailures = 0;
@@ -417,16 +428,22 @@ export class SenderManager extends StateManager {
 
       if (success) {
         this.clearPersistedEvents();
-        callbacks?.onSuccess?.(persistedData.events.length, persistedData.events, recoveryBody);
+        callbacks?.onSuccess?.(
+          persistedData.events.length,
+          persistedData.events,
+          recoveryBody,
+          this.lastIngestionReceipt ?? undefined,
+        );
       } else {
         this.persistEventsWithFailureCount(recoveryBody, recoveryFailures + 1, true);
         callbacks?.onFailure?.();
       }
     } catch (error) {
       if (error instanceof PermanentError) {
+        this.lastIngestionReceipt = error.ingestionReceipt ?? null;
         this.logPermanentError('Permanent error during recovery, clearing persisted events', error);
         this.clearPersistedEvents();
-        callbacks?.onFailure?.();
+        callbacks?.onFailure?.(this.lastIngestionReceipt ?? undefined);
         return;
       }
 
@@ -445,6 +462,11 @@ export class SenderManager extends StateManager {
    * intentionally kept in localStorage for recovery.
    */
   stop(): void {}
+
+  /** Most recent validated receipt, or null for legacy/non-HTTP outcomes. */
+  getLastIngestionReceipt(): Readonly<IngestionReceipt> | null {
+    return this.lastIngestionReceipt;
+  }
 
   private async backoffDelay(attempt: number): Promise<void> {
     const exponentialDelay = RETRY_BACKOFF_BASE_MS * Math.pow(2, attempt);
@@ -498,6 +520,7 @@ export class SenderManager extends StateManager {
         const response = await this.sendWithTimeout(url, payload);
 
         if (response.ok) {
+          this.lastIngestionReceipt = await this.readIngestionReceipt(response);
           if (attempt > 1) {
             log('info', `Send succeeded after ${attempt - 1} retry attempt(s)`, {
               data: { events: requestBody.events.length, attempt },
@@ -631,11 +654,11 @@ export class SenderManager extends StateManager {
           response.status >= 400 && response.status < 500 && response.status !== 408 && response.status !== 429;
 
         if (isPermanentError) {
-          const responseCode = await this.readTraceLogErrorCode(response);
+          const { responseCode, receipt } = await this.readTraceLogResponseMetadata(response);
           const message = responseCode
             ? `HTTP ${response.status}: ${response.statusText} (${responseCode})`
             : `HTTP ${response.status}: ${response.statusText}`;
-          throw new PermanentError(message, response.status, responseCode);
+          throw new PermanentError(message, response.status, responseCode, receipt ?? undefined);
         }
 
         if (response.status === 429) {
@@ -664,7 +687,7 @@ export class SenderManager extends StateManager {
    * Extracts the application error code from a 4xx body, and with it the proof that a TraceLog
    * host — not an arbitrary server answering the same name — produced the response.
    *
-   * Only the ingest error envelope is accepted: `{ statusCode, error, message, timestamp, path }`,
+   * Only the ingest error envelope is accepted: `{ statusCode, error, message, timestamp, path, ...receipt }`,
    * the single shape every rejection arrives in (tracelog-middleware's `AllExceptionsFilter`, which
    * renders an exception's own `code` into `error`). `error` counts only when `statusCode` echoes
    * the HTTP status — that pairing is the envelope's signature, and neither a generic
@@ -675,16 +698,28 @@ export class SenderManager extends StateManager {
    * would let any responder authorize a claim about TraceLog's own records. `undefined` therefore
    * means exactly "nothing here identifies the responder as TraceLog".
    */
-  private async readTraceLogErrorCode(response: Response): Promise<string | undefined> {
+  private async readTraceLogResponseMetadata(
+    response: Response,
+  ): Promise<{ responseCode?: string; receipt: IngestionReceipt | null }> {
     try {
       const body = (await response.clone().json()) as { statusCode?: unknown; error?: unknown };
+      const receipt = parseIngestionReceipt(body);
       if (body.statusCode === response.status && isUsableErrorCode(body.error)) {
-        return body.error;
+        return { responseCode: body.error, receipt };
       }
+      return { receipt };
     } catch {
       // Best-effort only. Status still determines permanence.
     }
-    return undefined;
+    return { receipt: null };
+  }
+
+  private async readIngestionReceipt(response: Response): Promise<IngestionReceipt | null> {
+    try {
+      return parseIngestionReceipt(await response.clone().json());
+    } catch {
+      return null;
+    }
   }
 
   private sendQueueSyncInternal(body: EventsQueue): boolean {

--- a/src/pixel/index.ts
+++ b/src/pixel/index.ts
@@ -3,3 +3,4 @@ export { mapEventToBody, SHOPIFY_EVENTS, SHOPIFY_PIXEL_EVENT_NAMES } from './eve
 export type { ShopifyEventName, ShopifyPixelEventName } from './event-mapper';
 export { sendBatch } from './pixel-sender';
 export type { PixelEventBody, PixelSenderSettings } from './pixel-sender';
+export type { IngestionReceipt, IngestionOutcome, IngestionRejectionReason } from '../types/ingestion-receipt.types';

--- a/src/pixel/pixel-sender.ts
+++ b/src/pixel/pixel-sender.ts
@@ -5,9 +5,11 @@
  * `api.tracelog.io/events/collect` — because the middleware has the only CORS
  * handler that accepts `Origin: null` from sandboxed iframes.
  *
- * Best-effort: failures are silently swallowed. The webhook (Task 03) carries
- * the revenue contract; pixel events are funnel-only and accept ~5-30% loss.
+ * Best-effort: failures are silently swallowed. The authenticated server-side
+ * webhook carries the revenue contract; pixel events are funnel-only.
  */
+
+import { type IngestionReceipt, parseIngestionReceipt } from '../types/ingestion-receipt.types';
 
 const INGEST_HOST = 'https://ingest.tracelog.io';
 
@@ -30,24 +32,32 @@ export interface PixelEventBody {
   _metadata: { client_version: string; timestamp: number };
 }
 
-export function sendBatch(settings: PixelSenderSettings, body: PixelEventBody): void {
+export async function sendBatch(settings: PixelSenderSettings, body: PixelEventBody): Promise<IngestionReceipt | null> {
   // Trust boundary is the Shopify extension settings form, but a misconfigured
   // (empty) projectId would yield `https://ingest.tracelog.io/p//collect` and
   // 404 every event. Drop silently so it can be diagnosed via Shopify pixel logs.
-  if (!settings.projectId) return;
+  if (!settings.projectId) return null;
 
   // Encode in case the merchant pastes whitespace, slashes, or other unsafe
   // characters into the Shopify extension settings form.
   const url = `${INGEST_HOST}/p/${encodeURIComponent(settings.projectId)}/collect`;
   try {
-    void fetch(url, {
+    const response = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       keepalive: true,
       body: JSON.stringify(body),
-    }).catch(() => {});
+    });
+
+    if (typeof response.json !== 'function') return null;
+    try {
+      return parseIngestionReceipt(await response.json());
+    } catch {
+      return null;
+    }
   } catch {
     // Pixel runs inside Shopify's strict sandbox; fetch() may be unavailable
     // or throw synchronously. Funnel events are best-effort — drop silently.
+    return null;
   }
 }

--- a/src/pixel/shopify-pixel.ts
+++ b/src/pixel/shopify-pixel.ts
@@ -21,7 +21,7 @@ export function registerShopifyPixel(api: ShopifyPixelApi, settings: PixelSender
   const handle = (eventName: ShopifyEventName, payload: unknown): void => {
     const body = mapEventToBody(payload as Parameters<typeof mapEventToBody>[0], eventName);
     if (!body) return;
-    sendBatch(settings, body);
+    void sendBatch(settings, body);
   };
 
   api.analytics.subscribe('cart_viewed', (event) => {

--- a/src/types/error.types.ts
+++ b/src/types/error.types.ts
@@ -2,6 +2,8 @@
  * Custom error types for TraceLog
  */
 
+import type { IngestionReceipt } from './ingestion-receipt.types';
+
 /**
  * Represents a permanent HTTP error (4xx) that should not be retried
  * Examples: 400 Bad Request, 403 Forbidden, 404 Not Found
@@ -11,6 +13,7 @@ export class PermanentError extends Error {
     message: string,
     public readonly statusCode?: number,
     public readonly responseCode?: string,
+    public readonly ingestionReceipt?: IngestionReceipt,
   ) {
     super(message);
     this.name = 'PermanentError';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export * from './device.types';
 export * from './emitter.types';
 export * from './error.types';
 export * from './event.types';
+export * from './ingestion-receipt.types';
 export * from './mode.types';
 export * from './queue.types';
 export * from './state.types';

--- a/src/types/ingestion-receipt.types.ts
+++ b/src/types/ingestion-receipt.types.ts
@@ -1,0 +1,49 @@
+export type IngestionOutcome = 'accepted' | 'partial' | 'rejected';
+
+export type IngestionRejectionReason = 'session_band' | 'event_guardrail' | 'project_paused' | 'account_closed';
+
+export interface IngestionReceipt {
+  outcome: IngestionOutcome;
+  accepted: number;
+  duplicates: number;
+  dropped: number;
+  reason?: IngestionRejectionReason;
+  retryAt?: string;
+  coverage: 'complete' | 'partial';
+}
+
+const REJECTION_REASONS: readonly IngestionRejectionReason[] = [
+  'session_band',
+  'event_guardrail',
+  'project_paused',
+  'account_closed',
+];
+
+/** Parses the additive receipt while remaining compatible with legacy boolean/empty bodies. */
+export function parseIngestionReceipt(value: unknown): IngestionReceipt | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const body = value as Record<string, unknown>;
+  if (body.outcome !== 'accepted' && body.outcome !== 'partial' && body.outcome !== 'rejected') return null;
+  if (body.coverage !== 'complete' && body.coverage !== 'partial') return null;
+
+  const count = (candidate: unknown): number | null =>
+    typeof candidate === 'number' && Number.isInteger(candidate) && candidate >= 0 ? candidate : null;
+  const accepted = count(body.accepted);
+  const duplicates = count(body.duplicates);
+  const dropped = count(body.dropped);
+  if (accepted === null || duplicates === null || dropped === null) return null;
+
+  const reason = REJECTION_REASONS.includes(body.reason as IngestionRejectionReason)
+    ? (body.reason as IngestionRejectionReason)
+    : undefined;
+
+  return {
+    outcome: body.outcome,
+    accepted,
+    duplicates,
+    dropped,
+    ...(reason ? { reason } : {}),
+    ...(typeof body.retryAt === 'string' ? { retryAt: body.retryAt } : {}),
+    coverage: body.coverage,
+  };
+}

--- a/tests/unit/managers/sender-manager.test.ts
+++ b/tests/unit/managers/sender-manager.test.ts
@@ -157,6 +157,26 @@ describe('SenderManager - async send via fetch()', () => {
     expect(storage.getItem(QUEUE_KEY(USER_ID))).toBeNull();
   });
 
+  it('exposes a validated partial receipt without retrying or persisting the delivered batch', async () => {
+    const receipt = {
+      outcome: 'partial',
+      accepted: 1,
+      duplicates: 0,
+      dropped: 1,
+      coverage: 'partial',
+    } as const;
+    (global as any).fetch = vi.fn().mockResolvedValue(jsonResponse(201, receipt));
+
+    const { sender, storage } = makeSender();
+    const onSuccess = vi.fn();
+
+    await expect(sender.sendEventsQueue(makeQueue(), { onSuccess })).resolves.toBe(true);
+
+    expect(onSuccess.mock.calls[0]?.[3]).toEqual(receipt);
+    expect(sender.getLastIngestionReceipt()).toEqual(receipt);
+    expect(storage.getItem(QUEUE_KEY(USER_ID))).toBeNull();
+  });
+
   it('attaches idempotency_token, client_version and referer to the request payload', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200));
     (global as any).fetch = fetchMock;
@@ -204,6 +224,36 @@ describe('SenderManager - async send via fetch()', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(onFailure).toHaveBeenCalledTimes(1);
     // Permanent errors clear pre-existing persistence to break retry loops.
+    expect(storage.getItem(QUEUE_KEY(USER_ID))).toBeNull();
+  });
+
+  it('surfaces a 402 rejection receipt while discarding the permanently refused batch', async () => {
+    const receipt = {
+      outcome: 'rejected',
+      accepted: 0,
+      duplicates: 0,
+      dropped: 2,
+      reason: 'session_band',
+      retryAt: '2026-09-01T00:00:00.000Z',
+      coverage: 'partial',
+    } as const;
+    const response = ingestErrorResponse(402, 'SESSION_BAND_PAUSED');
+    response.json = async (): Promise<unknown> =>
+      await Promise.resolve({
+        statusCode: 402,
+        error: 'SESSION_BAND_PAUSED',
+        message: 'Normal ingestion is paused for this accounting period.',
+        ...receipt,
+      });
+    (global as any).fetch = vi.fn().mockResolvedValue(response);
+
+    const { sender, storage } = makeSender();
+    const onFailure = vi.fn();
+
+    await expect(sender.sendEventsQueue(makeQueue(), { onFailure })).resolves.toBe(false);
+
+    expect(onFailure).toHaveBeenCalledWith(receipt);
+    expect(sender.getLastIngestionReceipt()).toEqual(receipt);
     expect(storage.getItem(QUEUE_KEY(USER_ID))).toBeNull();
   });
 

--- a/tests/unit/pixel/pixel-sender.test.ts
+++ b/tests/unit/pixel/pixel-sender.test.ts
@@ -41,21 +41,21 @@ describe('sendBatch', () => {
   });
 
   it('posts to ingest.tracelog.io/p/<projectId>/collect', () => {
-    sendBatch({ projectId: 'proj-abc' }, BODY);
+    void sendBatch({ projectId: 'proj-abc' }, BODY);
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy.mock.calls[0]![0]).toBe('https://ingest.tracelog.io/p/proj-abc/collect');
   });
 
   it('does NOT post to api.tracelog.io (CORS handler is on the middleware)', () => {
-    sendBatch({ projectId: 'proj-abc' }, BODY);
+    void sendBatch({ projectId: 'proj-abc' }, BODY);
 
     const url = fetchSpy.mock.calls[0]![0] as string;
     expect(url).not.toContain('api.tracelog.io');
   });
 
   it('uses POST + JSON content-type + keepalive', () => {
-    sendBatch({ projectId: 'proj-abc' }, BODY);
+    void sendBatch({ projectId: 'proj-abc' }, BODY);
 
     const init = fetchSpy.mock.calls[0]![1] as RequestInit;
     expect(init.method).toBe('POST');
@@ -64,7 +64,7 @@ describe('sendBatch', () => {
   });
 
   it('serializes body to JSON', () => {
-    sendBatch({ projectId: 'proj-abc' }, BODY);
+    void sendBatch({ projectId: 'proj-abc' }, BODY);
 
     const init = fetchSpy.mock.calls[0]![1] as RequestInit;
     const parsed = JSON.parse(init.body as string);
@@ -73,11 +73,24 @@ describe('sendBatch', () => {
     expect(parsed.events[0].custom_event.name).toBe('shopify_checkout_started');
   });
 
+  it('returns the same validated receipt contract used by the standard sender', async () => {
+    const receipt = {
+      outcome: 'partial',
+      accepted: 1,
+      duplicates: 0,
+      dropped: 1,
+      coverage: 'partial',
+    } as const;
+    fetchSpy.mockResolvedValue({ ok: true, json: async () => await Promise.resolve(receipt) });
+
+    await expect(sendBatch({ projectId: 'proj-abc' }, BODY)).resolves.toEqual(receipt);
+  });
+
   it('swallows fetch rejections silently', () => {
     global.fetch = vi.fn().mockRejectedValue(new TypeError('network down'));
 
     expect(() => {
-      sendBatch({ projectId: 'proj-abc' }, BODY);
+      void sendBatch({ projectId: 'proj-abc' }, BODY);
     }).not.toThrow();
   });
 
@@ -87,18 +100,18 @@ describe('sendBatch', () => {
     });
 
     expect(() => {
-      sendBatch({ projectId: 'proj-abc' }, BODY);
+      void sendBatch({ projectId: 'proj-abc' }, BODY);
     }).not.toThrow();
   });
 
   it('drops the request when projectId is empty (avoids 404 on `/p//collect`)', () => {
-    sendBatch({ projectId: '' }, BODY);
+    void sendBatch({ projectId: '' }, BODY);
 
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it('URL-encodes projectId so unsafe characters cannot break the path', () => {
-    sendBatch({ projectId: 'proj abc/foo?bar' }, BODY);
+    void sendBatch({ projectId: 'proj abc/foo?bar' }, BODY);
 
     const url = fetchSpy.mock.calls[0]![0] as string;
     expect(url).toBe('https://ingest.tracelog.io/p/proj%20abc%2Ffoo%3Fbar/collect');

--- a/tests/unit/types/ingestion-receipt.test.ts
+++ b/tests/unit/types/ingestion-receipt.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { parseIngestionReceipt } from '../../../src/types/ingestion-receipt.types';
+
+describe('parseIngestionReceipt', () => {
+  it('accepts the stable receipt fields and ignores additive envelope metadata', () => {
+    expect(
+      parseIngestionReceipt({
+        statusCode: 402,
+        currentPlan: 'PRO',
+        outcome: 'rejected',
+        accepted: 0,
+        duplicates: 0,
+        dropped: 4,
+        reason: 'session_band',
+        retryAt: '2026-09-01T00:00:00.000Z',
+        coverage: 'partial',
+      }),
+    ).toEqual({
+      outcome: 'rejected',
+      accepted: 0,
+      duplicates: 0,
+      dropped: 4,
+      reason: 'session_band',
+      retryAt: '2026-09-01T00:00:00.000Z',
+      coverage: 'partial',
+    });
+  });
+
+  it.each([
+    null,
+    true,
+    {},
+    { outcome: 'accepted', accepted: -1, duplicates: 0, dropped: 0, coverage: 'complete' },
+    { outcome: 'unknown', accepted: 1, duplicates: 0, dropped: 0, coverage: 'complete' },
+  ])('returns null for a legacy or malformed body', (body) => {
+    expect(parseIngestionReceipt(body)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds the typed ingestion receipt contract and client handling for accepted, partial and permanently rejected batches.

## Why

The browser library must not retry permanent policy rejections indefinitely and must preserve explicit coverage outcomes.

## Stack

Merge after the API TRA-472 metering PR. The API TRA-474 lifecycle PR completes the durable order-ledger side of the contract.